### PR TITLE
Use psr event dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "fzaninotto/faker": "^1.9",
         "nikic/iter": "^2.0",
         "psr/cache": "^1.0",
-        "symfony/event-dispatcher-contracts": "^1.1"
+        "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/src/Event/ObjectEvent.php
+++ b/src/Event/ObjectEvent.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace PHPSharkTank\Anonymizer\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
+use Psr\EventDispatcher\StoppableEventInterface;
 
-class ObjectEvent extends Event
+class ObjectEvent implements StoppableEventInterface
 {
     private $object;
+
+    private $propagationStopped = false;
 
     public function __construct($object)
     {
@@ -18,5 +20,15 @@ class ObjectEvent extends Event
     public function getObject()
     {
         return $this->object;
+    }
+
+    public function isPropagationStopped(): bool
+    {
+        return $this->propagationStopped;
+    }
+
+    public function stopPropagation(): void
+    {
+        $this->propagationStopped = true;
     }
 }

--- a/src/Visitor/GraphNavigator.php
+++ b/src/Visitor/GraphNavigator.php
@@ -10,7 +10,7 @@ use PHPSharkTank\Anonymizer\Exception\MetadataNotFoundException;
 use PHPSharkTank\Anonymizer\Loader\LoaderInterface;
 use PHPSharkTank\Anonymizer\Metadata\PropertyMetadata;
 use PHPSharkTank\Anonymizer\Registry\HandlerRegistryInterface;
-use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 
 final class GraphNavigator implements GraphNavigatorInterface
 {


### PR DESCRIPTION
Instead of `symfony/contratcts` we can use the `psr/event-dispatcher`, which made the library more flexible/independent.